### PR TITLE
Changed english appendix caption

### DIFF
--- a/configuration/thesis_config.tex
+++ b/configuration/thesis_config.tex
@@ -77,8 +77,8 @@
   \renewcommand{\bibname}{Referenties}
 }
 \addto\captionsenglish{%
-  \renewcommand\appendixname{Bijlagen}
-  \renewcommand\appendixpagename{Bijlage}
+  \renewcommand\appendixname{Appendices}
+  \renewcommand\appendixpagename{Appendix}
   \renewcommand{\refname}{References}
   \renewcommand{\bibname}{References}
 }


### PR DESCRIPTION
In thesis_config.tex the caption for english appendices is in dutch. This is changed to english