### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,7 +243,6 @@ TSWLatexianTemp*
 
 # generated if using elsarticle.cls
 *.spl
-/main.pdf
 /example.pdf
 # do not put your personal signature in any repo
 authenticity_signature.png


### PR DESCRIPTION
show a built main.pdf in repo. Do not expect the repo to be built before the result can be viewed.